### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/lib/scimgateway.js
+++ b/lib/scimgateway.js
@@ -896,12 +896,12 @@ const ScimGateway = function () {
       attribute: undefined,
       operator: undefined,
       value: undefined,
-      rawFilter: ctx.query.filter, // included for advanced filtering
+      rawFilter: Array.isArray(ctx.query.filter) ? ctx.query.filter.join(' ') : ctx.query.filter, // included for advanced filtering
       startIndex: undefined,
       count: undefined
     }
 
-    if (ctx.query.filter) {
+    if (ctx.query.filter && typeof ctx.query.filter === 'string') {
       ctx.query.filter = ctx.query.filter.trim()
       const arrFilter = ctx.query.filter.split(' ')
       if (arrFilter.length === 3 || (arrFilter.length > 2 && arrFilter[2].startsWith('"') && arrFilter[arrFilter.length - 1].endsWith('"'))) {


### PR DESCRIPTION
Potential fixes for 2 code scanning alerts from the [Address initial critical SAST detections](https://github.com/orgs/fulcrumapp/security/campaigns/3) security campaign:
- https://github.com/fulcrumapp/scimgateway/security/code-scanning/11
To fix the problem, we need to ensure that `ctx.query.excludedAttributes` is a string before using it. If it is not a string, we should handle it appropriately, such as by returning a bad request response. This can be done by adding a type check for `ctx.query.excludedAttributes` before using it.
  


- https://github.com/fulcrumapp/scimgateway/security/code-scanning/10
To fix the problem, we need to ensure that `ctx.query.filter` is always a string before using it. This can be done by adding a type check and handling the case where it is not a string. If `ctx.query.filter` is an array, we can either reject the request or convert the array to a string in a safe manner.

  The best way to fix the problem without changing existing functionality is to add a type check for `ctx.query.filter` before it is used. If it is not a string, we should handle it appropriately, such as by rejecting the request with a 400 status code.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
